### PR TITLE
updated lockfile so that we can push to heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,9 +113,15 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     nio4r (2.5.7)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
@@ -232,7 +238,9 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   capybara


### PR DESCRIPTION
When we tried to push our main branch to heroku, I got an error:

```
Your bundle only supports platforms ["x86_64-darwin-20"] but your local platform
remote:        is x86_64-linux. Add the current platform to the lockfile with `bundle lock
remote:        --add-platform x86_64-linux` and try again.
```

By running that `bundle lock` command, it seems not to throw errors when I push this "heroku try" branch to heroku. However, it seems that Heroku is waiting for a push from main, hence this pull request. 

Anything that demystifies what's going here would be helpful!